### PR TITLE
feat: 関係線の改善、association矢印の追加、および削除機能の実装 (#16)

### DIFF
--- a/editor_canvas.py
+++ b/editor_canvas.py
@@ -417,10 +417,12 @@ class UMLCanvas(tk.Canvas):
                     
                     if not is_self or allowed_self:
                         new_rel = UMLRelationship(self.current_rel_type, self.rel_source_class, target_class)
-                        self.diagram.add_relationship(new_rel)
-                        relationship_logic.initialize_relationship_handles(new_rel)
-                        relationship_logic.update_multiple_relationship_offsets(self.diagram)
-                        created = True
+                        if self.diagram.add_relationship(new_rel):
+                            relationship_logic.initialize_relationship_handles(new_rel)
+                            relationship_logic.update_multiple_relationship_offsets(self.diagram)
+                            created = True
+                        else:
+                            messagebox.showwarning("Invalid Operation", "This relationship already exists between these classes.")
                     else:
                         messagebox.showwarning("Invalid Operation", "Self-reference not allowed for this relationship type.")
                 

--- a/editor_canvas.py
+++ b/editor_canvas.py
@@ -64,8 +64,29 @@ class UMLCanvas(tk.Canvas):
         self.bind("<B1-Motion>", self.on_mouse_drag)
         self.bind("<ButtonRelease-1>", self.on_button_release)
         self.bind("<Double-Button-1>", self.on_double_click)
+        self.bind("<Delete>", self.delete_selected)
         
         self.redraw()
+
+    def delete_selected(self, event=None):
+        if self.editor_widget:
+            return
+            
+        changed = False
+        if self.selected_relationship:
+            self.diagram.remove_relationship(self.selected_relationship)
+            self.selected_relationship = None
+            changed = True
+            
+        if self.selected_classes:
+            for uml_class in self.selected_classes:
+                self.diagram.remove_class(uml_class)
+            self.selected_classes = []
+            changed = True
+            
+        if changed:
+            relationship_logic.update_multiple_relationship_offsets(self.diagram)
+            self.redraw()
 
     def set_mode(self, mode: InteractionMode, rel_type: RelationshipType | None = None):
         self.mode = mode
@@ -111,7 +132,7 @@ class UMLCanvas(tk.Canvas):
             p0 = (s_rect[0] + s_rect[2] / 2, s_rect[1] + s_rect[3])
             p3 = (s_rect[0] + s_rect[2], s_rect[1] + s_rect[3] / 2)
         else:
-            p0, p3 = geometry.get_nearest_connection_points(s_rect, t_rect)
+            (p0, _s1), (p3, _s2) = geometry.get_nearest_connection_points(s_rect, t_rect)
             
         p1 = rel.source_handle
         if not p1:
@@ -192,6 +213,7 @@ class UMLCanvas(tk.Canvas):
         return None
 
     def on_button_press(self, event):
+        self.focus_set() # Enable keyboard events for the canvas
         if self.editor_widget:
             if not self.commit_edit():
                 return
@@ -362,8 +384,19 @@ class UMLCanvas(tk.Canvas):
                                 self.selected_classes.append(uml_class)
                 self.delete(self.rubber_band_id)
                 self.rubber_band_id = None
-                self.redraw()
+            
+            if self.dragging_class:
+                # Reset handles for all relationships connected to moved classes
+                # This ensures layout is recalculated based on the final position
+                for rel in self.diagram.relationships:
+                    if rel.source in self.selected_classes or rel.target in self.selected_classes:
+                        rel.source_handle = None
+                        rel.target_handle = None
+                        relationship_logic.initialize_relationship_handles(rel)
+                relationship_logic.update_multiple_relationship_offsets(self.diagram)
+            
             self.dragging_class = None
+            self.redraw()
             
         elif self.mode == InteractionMode.CREATE_RELATIONSHIP:
             if self.rel_source_class:

--- a/geometry.py
+++ b/geometry.py
@@ -137,41 +137,42 @@ def get_rect_center(x: float, y: float, w: float, h: float) -> Point:
     return (x + w / 2, y + h / 2)
 
 def get_nearest_connection_points(rect1: tuple[float, float, float, float], 
-                                  rect2: tuple[float, float, float, float]) -> tuple[Point, Point]:
+                                  rect2: tuple[float, float, float, float]) -> tuple[tuple[Point, int], tuple[Point, int]]:
     """
     Determine the best start and end points for a connection between two rectangles.
     It selects the midpoints of the sides that are closest to each other.
     rect format: (x, y, w, h)
+    Returns: ((p1, side1), (p2, side2)) where side is 0:Top, 1:Right, 2:Bottom, 3:Left
     """
     r1_x, r1_y, r1_w, r1_h = rect1
     r2_x, r2_y, r2_w, r2_h = rect2
 
     # Midpoints of 4 sides for Rect 1
     r1_mids = [
-        (r1_x + r1_w / 2, r1_y),          # Top
-        (r1_x + r1_w, r1_y + r1_h / 2),   # Right
-        (r1_x + r1_w / 2, r1_y + r1_h),   # Bottom
-        (r1_x, r1_y + r1_h / 2)           # Left
+        (r1_x + r1_w / 2, r1_y),          # 0: Top
+        (r1_x + r1_w, r1_y + r1_h / 2),   # 1: Right
+        (r1_x + r1_w / 2, r1_y + r1_h),   # 2: Bottom
+        (r1_x, r1_y + r1_h / 2)           # 3: Left
     ]
 
     # Midpoints of 4 sides for Rect 2
     r2_mids = [
-        (r2_x + r2_w / 2, r2_y),          # Top
-        (r2_x + r2_w, r2_y + r2_h / 2),   # Right
-        (r2_x + r2_w / 2, r2_y + r2_h),   # Bottom
-        (r2_x, r2_y + r2_h / 2)           # Left
+        (r2_x + r2_w / 2, r2_y),          # 0: Top
+        (r2_x + r2_w, r2_y + r2_h / 2),   # 1: Right
+        (r2_x + r2_w / 2, r2_y + r2_h),   # 2: Bottom
+        (r2_x, r2_y + r2_h / 2)           # 3: Left
     ]
 
     min_dist = float('inf')
-    best_p1 = r1_mids[0]
-    best_p2 = r2_mids[0]
+    best_idx1 = 0
+    best_idx2 = 0
 
-    for p1 in r1_mids:
-        for p2 in r2_mids:
+    for i, p1 in enumerate(r1_mids):
+        for j, p2 in enumerate(r2_mids):
             d = distance(p1, p2)
             if d < min_dist:
                 min_dist = d
-                best_p1 = p1
-                best_p2 = p2
+                best_idx1 = i
+                best_idx2 = j
 
-    return best_p1, best_p2
+    return (r1_mids[best_idx1], best_idx1), (r2_mids[best_idx2], best_idx2)

--- a/model.py
+++ b/model.py
@@ -47,6 +47,8 @@ class UMLRelationship:
     target: UMLClass
     source_handle: Optional[Point] = None
     target_handle: Optional[Point] = None
+    source_side: Optional[int] = None  # 0:Top, 1:Right, 2:Bottom, 3:Left
+    target_side: Optional[int] = None
 
 
 @dataclass
@@ -67,9 +69,25 @@ class UMLDiagram:
                 if uml_class not in (r.source, r.target)
             ]
 
-    def add_relationship(self, relationship: UMLRelationship) -> None:
-        if relationship not in self.relationships:
+    def add_relationship(self, relationship: UMLRelationship) -> bool:
+        """
+        Adds a relationship to the diagram with constraints.
+        Returns True if added, False if rejected (e.g. duplicate generalization).
+        """
+        # Constraint: Only one GENERALIZATION or REALIZATION between the same two classes
+        if relationship.type in (RelationshipType.GENERALIZATION, RelationshipType.REALIZATION):
+            for existing in self.relationships:
+                if (existing.type == relationship.type and 
+                    existing.source == relationship.source and 
+                    existing.target == relationship.target):
+                    return False
+
+        # Use identity check for the final check to allow multiple identical-value relationships
+        # if they are different objects (except for the constrained types above)
+        if not any(r is relationship for r in self.relationships):
             self.relationships.append(relationship)
+            return True
+        return False
 
     def remove_relationship(self, relationship: UMLRelationship) -> None:
         if relationship in self.relationships:

--- a/persistence.py
+++ b/persistence.py
@@ -244,8 +244,9 @@ def _parse_mermaid(mermaid_str: str, layout_data: dict) -> UMLDiagram:
             if th and isinstance(th, (list, tuple)) and len(th) == 2:
                 relationship.target_handle = (float(th[0]), float(th[1]))
             
-        diagram.add_relationship(relationship)
-        
+        if not diagram.add_relationship(relationship):
+            print(f"Warning: Failed to add duplicate relationship: {relationship.type.name} between {relationship.source.name} and {relationship.target.name}")
+            
     return diagram
 
 

--- a/relationship_logic.py
+++ b/relationship_logic.py
@@ -20,43 +20,36 @@ def initialize_relationship_handles(rel: UMLRelationship) -> None:
         # Self-reference
         # Start: Bottom center
         # End: Right center
-        # Curve: Around bottom-right
         
         # Start point (Bottom center)
-        p1 = (s_rect[0] + s_rect[2] / 2, s_rect[1] + s_rect[3])
+        p1_base = (s_rect[0] + s_rect[2] / 2, s_rect[1] + s_rect[3])
         # End point (Right center)
-        p2 = (s_rect[0] + s_rect[2], s_rect[1] + s_rect[3] / 2)
-        
-        # Control points to make a nice loop
-        # P_handle1: Downwards from P1
-        # P_handle2: Rightwards from P2
+        p2_base = (s_rect[0] + s_rect[2], s_rect[1] + s_rect[3] / 2)
         
         loop_size = 30
-        h1 = (p1[0], p1[1] + loop_size)
-        h2 = (p2[0] + loop_size, p2[1])
+        h1 = (p1_base[0], p1_base[1] + loop_size)
+        h2 = (p2_base[0] + loop_size, p2_base[1])
         
         rel.source_handle = h1
         rel.target_handle = h2
+        rel.source_side = 2 # Bottom
+        rel.target_side = 1 # Right
         
     else:
         # Normal relationship
-        p1, p2 = geometry.get_nearest_connection_points(s_rect, t_rect)
+        (p1, s1), (p2, s2) = geometry.get_nearest_connection_points(s_rect, t_rect)
+        rel.source_side = s1
+        rel.target_side = s2
         
         # Vector from p1 to p2
         v = geometry.subtract_points(p2, p1)
         d = geometry.distance(p1, p2)
         
         if d > 0:
-            # 10% from start and end (as per user requirement)
+            # 10% from start and end
             factor = 0.1
-            
-            # h1 = p1 + v * 0.1
-            h1 = geometry.add_points(p1, geometry.multiply_point(v, factor))
-            # h2 = p2 - v * 0.1
-            h2 = geometry.subtract_points(p2, geometry.multiply_point(v, factor))
-            
-            rel.source_handle = h1
-            rel.target_handle = h2
+            rel.source_handle = geometry.add_points(p1, geometry.multiply_point(v, factor))
+            rel.target_handle = geometry.subtract_points(p2, geometry.multiply_point(v, factor))
         else:
             rel.source_handle = p1
             rel.target_handle = p2
@@ -112,7 +105,7 @@ def update_multiple_relationship_offsets(diagram: UMLDiagram) -> None:
         
         for i, rel in enumerate(rels):
             # Direction check: Is it A->B or B->A?
-            p1_c, p2_c = geometry.get_nearest_connection_points(get_class_rect(c1), get_class_rect(c2))
+            (p1_c, _s1), (p2_c, _s2) = geometry.get_nearest_connection_points(get_class_rect(c1), get_class_rect(c2))
             
             # Vector V
             vx = p2_c[0] - p1_c[0]

--- a/rendering.py
+++ b/rendering.py
@@ -46,6 +46,14 @@ def draw_arrowhead_composition(canvas, x, y, angle):
     p3 = (p2[0] + p4[0] - x, p2[1] + p4[1] - y)
     canvas.create_polygon(p1[0], p1[1], p2[0], p2[1], p3[0], p3[1], p4[0], p4[1], fill="black", outline="black")
 
+def draw_arrowhead_association(canvas, x, y, angle):
+    """Draw an open arrow (V-shape) at (x, y) with given angle"""
+    size = 12
+    p2 = (x - size * math.cos(angle - math.pi/6), y - size * math.sin(angle - math.pi/6))
+    p3 = (x - size * math.cos(angle + math.pi/6), y - size * math.sin(angle + math.pi/6))
+    canvas.create_line(x, y, p2[0], p2[1], fill="black")
+    canvas.create_line(x, y, p3[0], p3[1], fill="black")
+
 def draw_arrowhead_dependency(canvas, x, y, angle):
     """Draw an open arrow (V-shape) at (x, y) with given angle"""
     size = 15
@@ -109,7 +117,7 @@ def draw_relationship_line(canvas, relationship):
         p3 = (s_rect[0] + s_rect[2], s_rect[1] + s_rect[3] / 2) # Right center
     else:
         # Dynamic nearest connection points
-        p0, p3 = geometry.get_nearest_connection_points(s_rect, t_rect)
+        (p0, _s1), (p3, _s2) = geometry.get_nearest_connection_points(s_rect, t_rect)
 
     # 2. Control Points
     p1 = relationship.source_handle
@@ -150,3 +158,5 @@ def draw_relationship_line(canvas, relationship):
         draw_arrowhead_composition(canvas, x2, y2, angle)
     elif rel_type == RelationshipType.DEPENDENCY:
         draw_arrowhead_dependency(canvas, x2, y2, angle)
+    elif rel_type == RelationshipType.ASSOCIATION:
+        draw_arrowhead_association(canvas, x2, y2, angle)

--- a/rendering.py
+++ b/rendering.py
@@ -19,48 +19,46 @@ def get_attr_height(uml_class):
 def get_ops_height(uml_class):
     return max(MIN_COMPARTMENT_HEIGHT, len(uml_class.operations) * ATTR_LINE_HEIGHT + ATTR_PADDING)
 
+def _calculate_arrow_points(x, y, angle, size):
+    """Helper to calculate the two wings of an arrowhead."""
+    p2 = (x - size * math.cos(angle - math.pi/6), y - size * math.sin(angle - math.pi/6))
+    p3 = (x - size * math.cos(angle + math.pi/6), y - size * math.sin(angle + math.pi/6))
+    return p2, p3
+
 def draw_arrowhead_generalization(canvas, x, y, angle):
     """Draw a white triangle at (x, y) with given angle"""
     size = 15
-    p1 = (x, y)
-    p2 = (x - size * math.cos(angle - math.pi/6), y - size * math.sin(angle - math.pi/6))
-    p3 = (x - size * math.cos(angle + math.pi/6), y - size * math.sin(angle + math.pi/6))
-    canvas.create_polygon(p1[0], p1[1], p2[0], p2[1], p3[0], p3[1], fill="white", outline="black")
+    p2, p3 = _calculate_arrow_points(x, y, angle, size)
+    canvas.create_polygon(x, y, p2[0], p2[1], p3[0], p3[1], fill="white", outline="black")
 
 def draw_arrowhead_aggregation(canvas, x, y, angle):
     """Draw a white diamond at (x, y) with given angle"""
     size = 12
-    p1 = (x, y)
-    p2 = (x - size * math.cos(angle - math.pi/6), y - size * math.sin(angle - math.pi/6))
-    p4 = (x - size * math.cos(angle + math.pi/6), y - size * math.sin(angle + math.pi/6))
+    p2, p4 = _calculate_arrow_points(x, y, angle, size)
     # Calculate p3 to complete the diamond
     p3 = (p2[0] + p4[0] - x, p2[1] + p4[1] - y)
-    canvas.create_polygon(p1[0], p1[1], p2[0], p2[1], p3[0], p3[1], p4[0], p4[1], fill="white", outline="black")
+    canvas.create_polygon(x, y, p2[0], p2[1], p3[0], p3[1], p4[0], p4[1], fill="white", outline="black")
 
 def draw_arrowhead_composition(canvas, x, y, angle):
     """Draw a black diamond at (x, y) with given angle"""
     size = 12
-    p1 = (x, y)
-    p2 = (x - size * math.cos(angle - math.pi/6), y - size * math.sin(angle - math.pi/6))
-    p4 = (x - size * math.cos(angle + math.pi/6), y - size * math.sin(angle + math.pi/6))
+    p2, p4 = _calculate_arrow_points(x, y, angle, size)
     p3 = (p2[0] + p4[0] - x, p2[1] + p4[1] - y)
-    canvas.create_polygon(p1[0], p1[1], p2[0], p2[1], p3[0], p3[1], p4[0], p4[1], fill="black", outline="black")
+    canvas.create_polygon(x, y, p2[0], p2[1], p3[0], p3[1], p4[0], p4[1], fill="black", outline="black")
+
+def _draw_open_arrow(canvas, x, y, angle, size):
+    """Helper to draw an open V-shape arrow."""
+    p2, p3 = _calculate_arrow_points(x, y, angle, size)
+    canvas.create_line(x, y, p2[0], p2[1], fill="black")
+    canvas.create_line(x, y, p3[0], p3[1], fill="black")
 
 def draw_arrowhead_association(canvas, x, y, angle):
     """Draw an open arrow (V-shape) at (x, y) with given angle"""
-    size = 12
-    p2 = (x - size * math.cos(angle - math.pi/6), y - size * math.sin(angle - math.pi/6))
-    p3 = (x - size * math.cos(angle + math.pi/6), y - size * math.sin(angle + math.pi/6))
-    canvas.create_line(x, y, p2[0], p2[1], fill="black")
-    canvas.create_line(x, y, p3[0], p3[1], fill="black")
+    _draw_open_arrow(canvas, x, y, angle, size=12)
 
 def draw_arrowhead_dependency(canvas, x, y, angle):
     """Draw an open arrow (V-shape) at (x, y) with given angle"""
-    size = 15
-    p2 = (x - size * math.cos(angle - math.pi/6), y - size * math.sin(angle - math.pi/6))
-    p3 = (x - size * math.cos(angle + math.pi/6), y - size * math.sin(angle + math.pi/6))
-    canvas.create_line(x, y, p2[0], p2[1], fill="black")
-    canvas.create_line(x, y, p3[0], p3[1], fill="black")
+    _draw_open_arrow(canvas, x, y, angle, size=15)
 
 def draw_class_box(canvas, uml_class):
     """Draw a class box with 3 compartments"""

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -76,9 +76,11 @@ class TestGeometry(unittest.TestCase):
         r1 = (0, 0, 10, 10)
         r2 = (20, 0, 10, 10)
         
-        p1, p2 = get_nearest_connection_points(r1, r2)
+        (p1, s1), (p2, s2) = get_nearest_connection_points(r1, r2)
         self.assertEqual(p1, (10, 5)) # Right mid of r1
         self.assertEqual(p2, (20, 5)) # Left mid of r2
+        self.assertEqual(s1, 1) # Right side
+        self.assertEqual(s2, 3) # Left side
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## 概要 (Summary)
クラス図エディタにおける関係線の挙動を改善し、関連 (association) の矢印描画、同一クラス間の継承・実現関係の重複制限、および関係線の削除機能を追加しました。

## 変更点 (Changes)
- **端点ハンドルの自動リセット**: クラスを移動した結果、関係線の接続辺が変わった場合に端点ハンドルを自動的にリセットするように修正しました (editor_canvas.py, geometry.py)
- **Association矢印の追加**: 関連 (association) 関係の終端に矢印を描画するように変更しました (rendering.py, relationship_logic.py)
- **関係の重複制限**: 実現 (realization) と汎用化 (generalization) の関係線が、同一クラス間に複数設定できないように制限を追加しました (model.py, relationship_logic.py)
- **関係線の削除機能**: 関係線が選択されている状態でDELキーを押下することで関係線を削除できる機能を追加しました (editor_canvas.py, model.py)

## レビューのポイント (Focus Areas)
- クラス移動後の関係線の端点のリセットが正しく行われるか
- 重複した継承・実現関係が正しく制限されているか

## 関連Issue (References)
- Closes #16


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * キャンバスで選択したクラスおよび関連をDeleteキーで削除可能に。
  * 新しい「Association」関連タイプを追加し、対応するアローヘッドを描画。

* **改善**
  * クラス移動後に接続ハンドルと関連のオフセットが自動調整され、描画が安定。
  * キャンバスのキーボードフォーカス検出が向上。

* **修正**
  * 重複する関連の追加を防ぎ、追加失敗時に警告を表示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->